### PR TITLE
Fix clicking reset twice causes training data to not work

### DIFF
--- a/src/ai/WebcamClassifier.js
+++ b/src/ai/WebcamClassifier.js
@@ -175,7 +175,9 @@ export default class WebcamClassifier {
 
   clear(index) {
     const newMappedIndex = this.mappedButtonIndexes.indexOf(index);
-    this.classifier.clearClass(newMappedIndex);
+    if (newMappedIndex > -1) {
+        this.classifier.clearClass(newMappedIndex);
+    }
   }
 
   deleteClassData(index) {


### PR DESCRIPTION
Fixes the below issue described below.

**Issue**

1. Go to https://teachable-machine-v1.pages.dev/
2. Click "skip the tutorial"
3. Click the "Reset" class box for the first class twice to see error in console:
```
bundle.js:919 Uncaught Error: Cannot clear invalid class ${classIndex}
    at KNNClassifier.clearClass (bundle.js:919:19)
    at WebcamClassifier.clear (bundle.js:67815:25)
    at WebcamClassifier.deleteClassData (bundle.js:67822:12)
    at CamInput.resetClass (bundle.js:70011:29)
    at InputSection.resetClass (bundle.js:70607:27)
    at LearningClass.resetClass (bundle.js:70919:37)
``` 
4. Click to train for the first class. See new error in console:
```
index-C_tdOGDF.js:2015 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'classList')
    at GIFOutput.trigger (index-C_tdOGDF.js:2015:22368)
    at OutputSection.trigger (index-C_tdOGDF.js:2015:36273)
    at LearningSection.setConfidences (index-C_tdOGDF.js:1924:187506)
    at o (index-C_tdOGDF.js:1924:169331)
    at WebcamClassifier.animate (index-C_tdOGDF.js:1924:169558)
 ```
 5. Try training more data for the first class. Add/training of data does not work anymore. 
 
 
 **Note**
 
Though this PR fixes the issue described above, training data and then clicking the "Reset" class box button twice would still cause the `Cannot clear invalid class ${classIndex}` error. This issue is also in https://teachablemachine.withgoogle.com/v1/ 

**Preview link**
https://fix-reset-class.teachable-machine-v1.pages.dev/