### PR TITLE
Webcam permission error message

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,9 @@
                         <div id="input-section" class="section section--disabled input section--input">
                             <h2 class="section__title"><span>Input</span></h2>
                             <div class="section__container">
-                                <div class="input__media"></div>
+                                <div class="input__media">
+                                    <p id="input__media__activate" class="input__media__activate"></p>
+                                </div>
                                 <a href="" class="input__media__flip" id="input__media__flip"></a>
                             </div>
                         </div>
@@ -305,7 +307,6 @@
     <a href="https://experiments.withgoogle.com/ai" target="_blank" class="link"><img class="footer__image" src="./static/footer.svg" alt="Made with some friends at Google"></a>
     <a href="https://www.google.com/policies/" target="_blank" class="link link--privacy">Privacy &amp; Terms</a>
 </footer>
-<p id="input__media__activate" class="input__media__activate"></p>
 </div>
 <script>
     window.gtag = () => {};

--- a/src/ai/WebcamClassifier.js
+++ b/src/ai/WebcamClassifier.js
@@ -69,11 +69,6 @@ export default class WebcamClassifier {
     this.init();
 
     this.activateWebcamButton = document.getElementById('input__media__activate');
-    if (this.activateWebcamButton) {
-      this.activateWebcamButton.addEventListener('click', () => {
-        location.reload();
-      });
-    }
   }
 
   startWebcam() {
@@ -115,7 +110,9 @@ export default class WebcamClassifier {
             error: error
           }
         });
-        this.activateWebcamButton.style.display = 'block';
+        this.activateWebcamButton.style.display = 'flex';
+        this.activateWebcamButton.innerHTML = getMediaPermissionErrorMsg(error)
+
         window.dispatchEvent(event);
         gtag('event', 'webcam_denied');
       });
@@ -346,3 +343,4 @@ export default class WebcamClassifier {
 import * as tf from '@tensorflow/tfjs';
 import * as knnClassifier from '@tensorflow-models/knn-classifier';
 import * as mobilenet from '@tensorflow-models/mobilenet';
+import { getMediaPermissionErrorMsg } from './webcamPermissionError.js'

--- a/src/ai/webcamPermissionError.js
+++ b/src/ai/webcamPermissionError.js
@@ -1,0 +1,60 @@
+// Based on https://github.com/helenamerk/mic-check/blob/main/src/requestMediaPermissions.tsx.
+
+const mediaPermissionsErrorMsg = {
+	/** (macOS) browser does not have permission to access cam/mic */
+	SystemPermissionDenied: 'Your browser cannot access your camera/microphone. Make sure permissions are enabled in your browser settings.',
+	/** user denied permission for site to access cam/mic */
+	UserPermissionDenied: 'There was an error accessing your camera/microphone. Make sure permissions are enabled.',
+	/** (Windows) browser does not have permission to access cam/mic OR camera is in use by another application or browser tab */
+	CouldNotStartVideoSource: 'Another application or browser tab may already be using your webcam. Please turn off other cameras before proceeding.',
+	/** all other errors */
+	Generic: 'There was an error accessing your camera/microphone. Make sure permissions are enabled, or ask for help.',
+}
+
+export const getMediaPermissionErrorMsg = (error) => {
+  console.log(error.name, error.message)
+  const errName = error.name
+  const errMessage = error.message
+  if (GLOBALS.browserUtils.isChrome) {
+    if (errName === 'NotAllowedError' && errMessage === 'Permission denied by system') {
+      return mediaPermissionsErrorMsg.SystemPermissionDenied;
+    } 
+    if (errName === 'NotAllowedError' && errMessage === 'Permission denied') {
+      return mediaPermissionsErrorMsg.UserPermissionDenied;
+    }
+    if (errName === 'NotReadableError') {
+      return mediaPermissionsErrorMsg.CouldNotStartVideoSource;
+    }
+  } 
+  if (GLOBALS.browserUtils.isSafari && errName === 'NotAllowedError') {
+    return mediaPermissionsErrorMsg.UserPermissionDenied;
+  } 
+  if (GLOBALS.browserUtils.isEdge) {
+    if (errName === 'NotAllowedError') {
+      return mediaPermissionsErrorMsg.UserPermissionDenied;
+    } 
+    if (errName === 'NotReadableError') {
+      return mediaPermissionsErrorMsg.CouldNotStartVideoSource;
+    }
+  } 
+  if (GLOBALS.browserUtils.isFirefox) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#exceptions
+    if (errName === 'NotFoundError') {
+      return mediaPermissionsErrorMsg.SystemPermissionDenied;
+    } 
+    if (errName === 'NotReadableError') {
+      return mediaPermissionsErrorMsg.SystemPermissionDenied;
+    } 
+    if (errName === 'NotAllowedError') {
+      return mediaPermissionsErrorMsg.UserPermissionDenied;
+    }
+    if (errName === 'AbortError') {
+      return mediaPermissionsErrorMsg.CouldNotStartVideoSource;
+    }
+  }
+
+  return mediaPermissionsErrorMsg.Generic;
+}
+
+
+import GLOBALS from '../config.js';

--- a/src/ai/webcamPermissionError.js
+++ b/src/ai/webcamPermissionError.js
@@ -12,7 +12,6 @@ const mediaPermissionsErrorMsg = {
 }
 
 export const getMediaPermissionErrorMsg = (error) => {
-  console.log(error.name, error.message)
   const errName = error.name
   const errMessage = error.message
   if (GLOBALS.browserUtils.isChrome) {

--- a/src/ai/webcamPermissionError.js
+++ b/src/ai/webcamPermissionError.js
@@ -2,11 +2,11 @@
 
 const mediaPermissionsErrorMsg = {
 	/** (macOS) browser does not have permission to access cam/mic */
-	SystemPermissionDenied: 'Your browser cannot access your camera/microphone. Make sure permissions are enabled in your browser settings.',
+	SystemPermissionDenied: 'Your browser cannot access your camera/microphone. Make sure permissions are enabled in your browser settings. Reload the page.',
 	/** user denied permission for site to access cam/mic */
-	UserPermissionDenied: 'There was an error accessing your camera/microphone. Make sure permissions are enabled.',
+	UserPermissionDenied: 'There was an error accessing your camera/microphone. Make sure permissions are enabled, then reload the page.',
 	/** (Windows) browser does not have permission to access cam/mic OR camera is in use by another application or browser tab */
-	CouldNotStartVideoSource: 'Another application or browser tab may already be using your webcam. Please turn off other cameras before proceeding.',
+	CouldNotStartVideoSource: 'Another application or browser tab may already be using your webcam. Please turn off other cameras and reload the page.',
 	/** all other errors */
 	Generic: 'There was an error accessing your camera/microphone. Make sure permissions are enabled, or ask for help.',
 }

--- a/src/index.js
+++ b/src/index.js
@@ -49,19 +49,6 @@ function init() {
 	if (localStorage.getItem('isBackFacingCam') && localStorage.getItem('isBackFacingCam') === 'true') {
 		GLOBALS.isBackFacingCam = true;
 	}
-
-	// Camera status messages per browser
-	if (GLOBALS.browserUtils.isChrome && !GLOBALS.browserUtils.isEdge) {
-		document.querySelector('.input__media__activate').innerHTML = 'To teach your machine, <span class="input__media__activate--desktop"> you need to click up here to turn on your camera and then <a href="#">refresh the page</a>.</span><span class="input__media__activate--mobile"> you need to <a href="#">refresh the page</a> and allow camera access.</span></p>';
-
-		if (!GLOBALS.browserUtils.isCompatable) {
-			document.querySelector('.wizard__browser-warning').innerHTML = 'Something went wrong and we could not load the site, please try restarting your browser.';
-		}
-	}else if (GLOBALS.browserUtils.isSafari) {
-		document.querySelector('.input__media__activate').innerHTML = 'To teach your machine, you need to turn on your camera. To do this click "Safari" in the menu bar, navigate to "Settings for This Website", in the "Camera" drop down menu choose "Allow" and then <a href="#">refresh the page</a>.';
-	}else if (GLOBALS.browserUtils.isFirefox) {
-		document.querySelector('.input__media__activate').innerHTML = 'To teach your machine, you need to turn on your camera. To do this you need to click this icon <img class="camera-icon" src="static/ff-camera-icon.png"> to grant access and <a href="#">refresh the page</a>.';
-	}
 }
 
 window.addEventListener('load', init);

--- a/src/ui/modules/Wizard.js
+++ b/src/ui/modules/Wizard.js
@@ -444,11 +444,6 @@ this.lastClassTriggered = null;
 
 this.activateWebcamButton = document.getElementById('input__media__activate');
 this.activateWebcamButton.style.display = 'none';
-if (this.activateWebcamButton) {
-  this.activateWebcamButton.addEventListener('click', () => {
-    location.reload();
-});
-}
 
 
 this.resizeEvent = this.size.bind(this);
@@ -555,7 +550,6 @@ ended() {
             this.play(2);
         }else if (localStorage.getItem('webcam_status') === 'denied') {
             this.play(7);
-
         }
     }
 

--- a/style/components/machine.styl
+++ b/style/components/machine.styl
@@ -72,6 +72,7 @@
 	justify-content: center;
 	height: 100%;
 	color: $color__text--light;
+	margin: 0;
 }
 
 .input__media__activate--mobile {

--- a/style/components/machine.styl
+++ b/style/components/machine.styl
@@ -66,20 +66,12 @@
 
 .input__media__activate {
 	display: none
-	position: fixed
-	top: -20px
-	right: 0
-	width: 325px
-	background: white
 	padding: 20px
-	z-index: 999
-
-	.camera-icon {
-		display: inline-block
-		height: auto
-		max-width: 25px
-		vertical-align: middle
-	}
+	width: 100%
+	flex-direction: column;
+	justify-content: center;
+	height: 100%;
+	color: $color__text--light;
 }
 
 .input__media__activate--mobile {

--- a/style/components/output__led.styl
+++ b/style/components/output__led.styl
@@ -263,6 +263,7 @@
 	outline: none
 	position relative
 	cursor: pointer
+	width: 100%
 	
 	@extend .font__size--small
 }

--- a/style/components/output__servo.styl
+++ b/style/components/output__servo.styl
@@ -263,6 +263,7 @@
 	outline: none
 	position relative
 	cursor: pointer
+	width: 100%
 	
 	@extend .font__size--small
 }


### PR DESCRIPTION
- Move the webcam permission message box into the input box
- Remove the message box click listener that causes the page to reload when the box is clicked on
- Change error message depending on error raised