### PR TITLE
Reset mappedButtonIndexes if there are no classes in the classifier

### DIFF
--- a/src/ai/WebcamClassifier.js
+++ b/src/ai/WebcamClassifier.js
@@ -174,6 +174,11 @@ export default class WebcamClassifier {
     if (newMappedIndex > -1) {
         this.classifier.clearClass(newMappedIndex);
     }
+    // Reset mappedButtonIndexes when there is no class in the classifier.
+    const classCount = Object.keys(this.classifier.getClassExampleCount()).length
+    if (classCount === 0) {
+      this.mappedButtonIndexes = [];
+    }
   }
 
   deleteClassData(index) {


### PR DESCRIPTION
Fixes the following issue:
  1. Connect the micro:bit and web cam.
  2. Record data for any 1 class.
  3. Clear data for that class you recorded in step 2.
  4. Record some data for a new class, see no prediction inference being made or confidence shown.
  
Also, if there are any issues where prediction breaks (see below limitations), clearing all the classes examples should fix it. 

Preview: https://fix-reset.teachable-machine-v1.pages.dev/

**New found limitations**
  
The order at which the classes get recorded and cleared influences whether prediction breaks or not.
If you clear the classes in the reverse order that you recorded them, the predictions work ok.

For example:
- if you record green, purple, orange, then clear purple --> prediction breaks
  - "breaks" meaning it can only detect green class, if you record purple again, it fixes itself
- if you record green, purple, orange, then clear green --> prediction breaks.
- if you record green, purple, orange, then clear orange --> works ok (I think because orange was recorded last)
- if you record orange, purple, green, then clear green --> works ok (I think because green was recorded last, but the colours in the bars seem to disappear as well)


