### PR TITLE
Picture in picture support when MakeCode is open 

### DIFF
--- a/src/ai/WebcamClassifier.js
+++ b/src/ai/WebcamClassifier.js
@@ -355,6 +355,17 @@ export default class WebcamClassifier {
 
     this.timer = requestAnimationFrame(this.animate.bind(this));
   }
+
+  requestPictureInPicture() {
+      return this.video.requestPictureInPicture();
+  }
+
+  exitPictureInPicture() {
+      if (document.pictureInPictureElement) {
+        document.exitPictureInPicture();
+      }
+  }
+
 }
 import * as tf from '@tensorflow/tfjs';
 import * as knnClassifier from '@tensorflow-models/knn-classifier';

--- a/src/outputs/code/CodeEditor.js
+++ b/src/outputs/code/CodeEditor.js
@@ -99,9 +99,13 @@ class CodeEditor {
         window.history.pushState(null, "", "/code");
         Object.assign(this.element.style, editorVisibleStyles);
         window.addEventListener("popstate", () => {
+            GLOBALS.inputSection.exitPictureInPicture();
             Object.assign(this.element.style, editorHiddenStyles);
             this.clearClassDetection();
         }, { once: true })
+        GLOBALS.inputSection.requestPictureInPicture().catch(e => {
+            // Permissions, browser support. Nothing we can do.
+        })
     }
 
     close() {

--- a/src/ui/components/CamInput.js
+++ b/src/ui/components/CamInput.js
@@ -48,6 +48,7 @@ class CamInput {
     this.started = false;
     this.webcamClassifier.stopTimer();
     this.hide();
+    this.exitPictureInPicture();
   }
 
   hide() {
@@ -81,6 +82,14 @@ class CamInput {
             this.webcamClassifier.video.width = this.width;
             this.webcamClassifier.video.height = this.width / this.videoRatio;
     }*/
+  }
+
+  requestPictureInPicture() {
+      return this.webcamClassifier.requestPictureInPicture();
+  }
+
+  exitPictureInPicture() {
+      this.webcamClassifier.exitPictureInPicture();
   }
 }
 

--- a/src/ui/modules/InputSection.js
+++ b/src/ui/modules/InputSection.js
@@ -220,6 +220,14 @@ class InputSection {
             }
         }
     }
+
+    requestPictureInPicture() {
+        return this.camInput.requestPictureInPicture();
+    }
+
+    exitPictureInPicture() {
+        this.camInput.exitPictureInPicture();
+    }
 }
 
 import TweenMax from 'gsap/esm';

--- a/src/ui/modules/wizard/LaunchScreen.js
+++ b/src/ui/modules/wizard/LaunchScreen.js
@@ -163,6 +163,7 @@ class LaunchScreen {
         if (this.hasConnectedBefore) {
             this.displayConnectionError(connectionErrorMsg["disconnected"]);
         }
+        GLOBALS.camInput.stop();
     }
 
     async displayConnectionError(errMessage) {


### PR DESCRIPTION
Note that PIP remains open if you move to other tabs or even apps.
We could close and perhaps reopen (needs testing) it with more work, or perhaps reposition the video element ourselves (but would need move/resize/close UX). It has its own UX to close if annoying. Good enough for the demo?