### PR TITLE
Remove not needed broken line

### DIFF
--- a/src/outputs/LEDOutput.js
+++ b/src/outputs/LEDOutput.js
@@ -147,7 +147,6 @@ class LEDOutput {
 
     openMakeCode() {
         this.openCodeEditorWithProject(ledMakeCodeProject);
-        onEditorOpened()
     }
 
     onEditorOpened() {

--- a/src/outputs/ServoOutput.js
+++ b/src/outputs/ServoOutput.js
@@ -105,7 +105,6 @@ class ServoOutput {
 
     openMakeCode() {
         this.openCodeEditorWithProject(servoMakeCodeProject);
-        onEditorOpened()
     }
 
     onEditorOpened() {

--- a/src/outputs/SoundOutput.js
+++ b/src/outputs/SoundOutput.js
@@ -145,7 +145,6 @@ class SoundOutput {
 
     openMakeCode() {
         this.openCodeEditorWithProject(soundMakeCodeProject);
-        onEditorOpened()
     }
 
     onEditorOpened() {


### PR DESCRIPTION
`onEditorOpened` should require `this` for it to work, but the line is not needed anyway and causes confusion. 

`this.openCodeEditorWithProject` dispatches an event (see [here](https://github.com/microbit-matt-hillsdon/teachable-machine-v1/blob/tweak/src/ui/modules/OutputSection.js#L72-L73)), which is [handled by the `onEditorOpened` method](https://github.com/microbit-matt-hillsdon/teachable-machine-v1/blob/tweak/src/outputs/SoundOutput.js#L139) so it gets called properly in the end despite the broken line.

http://tweak.teachable-machine-v1.pages.dev/